### PR TITLE
Remove Docker-related extension from the Python preset

### DIFF
--- a/python.json5
+++ b/python.json5
@@ -1,10 +1,6 @@
 // Python related settings
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": [
-    // https://docs.renovatebot.com/presets-docker/#dockerpindigests
-    "docker:pinDigests"
-  ],
   "packageRules": [
     {
       "groupName": "Python",


### PR DESCRIPTION
This is a mistake I did in https://github.com/ulgens/renovate-presets/pull/8

`docker:pinDigests` is already included in the Docker preset, so no other changes is necessary.