### PR TITLE
Simplify the grouping logic for custom Python dep definitions

### DIFF
--- a/python.json5
+++ b/python.json5
@@ -19,8 +19,21 @@
     {
       "groupName": "Python Dependencies",
       "matchPackageNames": [
+        // Ruff related dependencies
+        // git hooks
+        // https://github.com/astral-sh/ruff-pre-commit
         "astral-sh/ruff-pre-commit",
-        "astral-sh/setup-uv", "ghcr.io/astral-sh/uv", "astral-sh/uv-pre-commit",
+
+        // uv related dependencies
+        // Docker image
+        // https://docs.astral.sh/uv/guides/integration/docker/
+        "ghcr.io/astral-sh/uv",
+        // GitHub Actions layer
+        // https://github.com/astral-sh/setup-uv
+        "astral-sh/setup-uv",
+        // git hooks
+        // https://github.com/astral-sh/uv-pre-commit
+        "astral-sh/uv-pre-commit",
       ],
     },
   ],


### PR DESCRIPTION
The previous approach was requiring an update everytime we need to handle a new package. Custom deps under CI workflows are already defined with `datasource=pypi`, which can be used for cleaner grouping logic.