### PR TITLE
Add ruff pypi package to custom Python packages list

### DIFF
--- a/python.json5
+++ b/python.json5
@@ -20,6 +20,10 @@
       "groupName": "Python Dependencies",
       "matchPackageNames": [
         // Ruff related dependencies
+        // pypi package - used in pyproject.toml for easier IDE integration
+        // This is already caught by pypi data source match,
+        // but duplicated here in sake of completeness - readability.
+        "ruff",
         // git hooks
         // https://github.com/astral-sh/ruff-pre-commit
         "astral-sh/ruff-pre-commit",

--- a/python.json5
+++ b/python.json5
@@ -20,9 +20,9 @@
       "groupName": "Python Dependencies",
       "matchPackageNames": [
         // Ruff related dependencies
-        // pypi package - used in pyproject.toml for easier IDE integration
+        // PyPI package - used in pyproject.toml for easier IDE integration
         // This is already caught by pypi data source match,
-        // but duplicated here in sake of completeness - readability.
+        // but duplicated here for the sake of completeness - readability.
         "ruff",
         // git hooks
         // https://github.com/astral-sh/ruff-pre-commit


### PR DESCRIPTION
This is already caught by pypi data source match, duplicated there in sake of completeness - readability.